### PR TITLE
fix: werkzeug 2.1.X support

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -31,7 +31,10 @@ except ImportError:
     except ImportError:
         from io import StringIO
 
-from werkzeug.wrappers import BaseRequest
+try: # werkzeug <= 2.0.3
+    from werkzeug.wrappers import BaseRequest
+except: # werkzeug > 2.1
+    from werkzeug.wrappers import Request as BaseRequest
 
 
 __version__ = '0.0.4'


### PR DESCRIPTION
resolves import error and I think it should work 

```
File "E:\flask-project\app.py", line 2, in <module>
    from flask_lambda import FlaskLambda
  File "E:\flask-project\venv\lib\site-packages\flask_lambda.py", line 33, in <module>
    from werkzeug.wrappers import BaseRequest
ImportError: cannot import name 'BaseRequest' from 'werkzeug.wrappers' (E:\flask-webhook-creator\venv\lib\site-packages\werkzeug\wrappers\__init__.py)
```